### PR TITLE
Removal of master and slave terminology

### DIFF
--- a/examples/basic.py
+++ b/examples/basic.py
@@ -10,32 +10,32 @@ rootpath = os.path.split(os.path.dirname(os.path.abspath(__file__)))[0]
 sys.path.append(rootpath)
 
 from mysql.replicant.commands import (
-    fetch_master_pos,
-    fetch_slave_pos,
+    fetch_main_pos,
+    fetch_subordinate_pos,
     )
 
 from mysql.replicant.errors import (
-    NotMasterError,
-    NotSlaveError,
+    NotMainError,
+    NotSubordinateError,
     )
 
 import my_deployment
 
 print "# Executing 'show databases'"
-for db in my_deployment.master.sql("show databases"):
+for db in my_deployment.main.sql("show databases"):
     print db["Database"]
 
 print "# Executing 'ls'"
-for line in my_deployment.master.ssh(["ls"]):
+for line in my_deployment.main.ssh(["ls"]):
     print line
 
 try:
-    print "Master position is:", fetch_master_pos(my_deployment.master)
-except NotMasterError:
-    print my_deployment.master.name, "is not configured as a master"
+    print "Main position is:", fetch_main_pos(my_deployment.main)
+except NotMainError:
+    print my_deployment.main.name, "is not configured as a main"
 
-for slave in my_deployment.slaves:
+for subordinate in my_deployment.subordinates:
     try:
-        print "Slave position is:", fetch_slave_pos(slave)
-    except NotSlaveError:
-        print slave.name, "not configured as a slave"
+        print "Subordinate position is:", fetch_subordinate_pos(subordinate)
+    except NotSubordinateError:
+        print subordinate.name, "not configured as a subordinate"

--- a/examples/load_balancer.py
+++ b/examples/load_balancer.py
@@ -58,7 +58,7 @@ class TestLoadBalancer(unittest.TestCase):
     "Class to test the load balancer functions."
 
     def setUp(self):
-        from my_deployment import common, master, slaves
+        from my_deployment import common, main, subordinates
         common.sql("DROP DATABASE IF EXISTS common")
         common.sql("CREATE DATABASE common")
         common.sql(_CREATE_TABLE)
@@ -70,23 +70,23 @@ class TestLoadBalancer(unittest.TestCase):
         common.sql("DROP DATABASE common")
 
     def testServers(self):
-        from my_deployment import common, master, slaves
+        from my_deployment import common, main, subordinates
 
         try:
-            pool_add(common, master, ['READ', 'WRITE'])
+            pool_add(common, main, ['READ', 'WRITE'])
         except AlreadyInPoolError:
-            pool_set(common, master, ['READ', 'WRITE'])
+            pool_set(common, main, ['READ', 'WRITE'])
 
-        for slave in slaves:
+        for subordinate in subordinates:
             try:
-                pool_add(common, slave, ['READ'])
+                pool_add(common, subordinate, ['READ'])
             except AlreadyInPoolError:
-                pool_set(common, slave, ['READ'])
+                pool_set(common, subordinate, ['READ'])
 
         for row in common.sql("SELECT * FROM nodes", db="common"):
-            if row['port'] == master.port:
+            if row['port'] == main.port:
                 self.assertEqual(row['type'], 'READ,WRITE')
-            elif row['port'] in [slave.port for slave in slaves]:
+            elif row['port'] in [subordinate.port for subordinate in subordinates]:
                 self.assertEqual(row['type'], 'READ')
 
 if __name__ == '__main__':

--- a/examples/my_deployment.py
+++ b/examples/my_deployment.py
@@ -17,7 +17,7 @@ from mysql.replicant.config import (
     ConfigManagerFile,
 )
 
-servers = [Server('master',
+servers = [Server('main',
                   server_id=1,
                   sql_user=User("mysql_replicant"),
                   ssh_user=User("mats"),
@@ -25,25 +25,25 @@ servers = [Server('master',
                   port=3307,
                   socket='/var/run/mysqld/mysqld1.sock',
                   ),
-           Server('slave1', server_id=2,
+           Server('subordinate1', server_id=2,
                   sql_user=User("mysql_replicant"),
                   ssh_user=User("mats"),
                   machine=Linux(),
                   port=3308,
                   socket='/var/run/mysqld/mysqld2.sock'),
-           Server('slave2', 
+           Server('subordinate2', 
                   sql_user=User("mysql_replicant"),
                   ssh_user=User("mats"),
                   machine=Linux(),
                   port=3309,
                   socket='/var/run/mysqld/mysqld3.sock'),
-           Server('slave3',
+           Server('subordinate3',
                   sql_user=User("mysql_replicant"),
                   ssh_user=User("mats"),
                   machine=Linux(),
                   port=3310,
                   socket='/var/run/mysqld/mysqld4.sock')]
 
-master = servers[0]
+main = servers[0]
 common = servers[0]              # Where the common database is stored
-slaves = servers[1:]
+subordinates = servers[1:]

--- a/examples/simple.py
+++ b/examples/simple.py
@@ -13,23 +13,23 @@ from mysql.replicant.server import (
     User,
     )
 from mysql.replicant.roles import (
-    Master,
+    Main,
     Final,
     )
 from mysql.replicant.commands import (
-    change_master,
+    change_main,
     )
 
-master_role = Master(User("repl_user", "xyzzy"))
-final_role = Final(my_deployment.master)
+main_role = Main(User("repl_user", "xyzzy"))
+final_role = Final(my_deployment.main)
 
 try:
-    master_role.imbue(my_deployment.master)
+    main_role.imbue(my_deployment.main)
 except IOError, e:
-    print "Cannot imbue master with Master role:", e
+    print "Cannot imbue main with Main role:", e
 
-for slave in my_deployment.slaves:
+for subordinate in my_deployment.subordinates:
     try:
-        final_role.imbue(slave)
+        final_role.imbue(subordinate)
     except IOError, e:
-        print "Cannot imbue slave with Final role:", e
+        print "Cannot imbue subordinate with Final role:", e

--- a/lib/mysql/replicant/backup.py
+++ b/lib/mysql/replicant/backup.py
@@ -35,7 +35,7 @@ class PhysicalBackup(BackupImage):
     def backup_server(self, server, database="*"):
 
         from mysql.replicant.commands import (
-            fetch_master_position,
+            fetch_main_position,
             )
 
         datadir = server.fetch_config().get('datadir')
@@ -43,7 +43,7 @@ class PhysicalBackup(BackupImage):
             database = [d for d in os.listdir(datadir)
                   if os.path.isdir(os.path.join(datadir, d))]
         server.sql("FLUSH TABLES WITH READ LOCK")
-        position = fetch_master_position(server)
+        position = fetch_main_position(server)
         if server.host != "localhost":
             path = os.path.basename(self.url.path)
         else:

--- a/lib/mysql/replicant/errors.py
+++ b/lib/mysql/replicant/errors.py
@@ -22,17 +22,17 @@ class NoOptionError(Error):
     "Exception raised when ConfigManager does not find the option"
     pass
 
-class SlaveNotRunningError(Error):
-    "Exception raised when slave is not running but were expected to run"
+class SubordinateNotRunningError(Error):
+    "Exception raised when subordinate is not running but were expected to run"
     pass
 
-class NotMasterError(Error):
-    """Exception raised when the server is not a master and the
+class NotMainError(Error):
+    """Exception raised when the server is not a main and the
     operation is illegal."""
     pass
 
-class NotSlaveError(Error):
-    """Exception raised when the server is not a slave and the
+class NotSubordinateError(Error):
+    """Exception raised when the server is not a subordinate and the
     operation is illegal."""
     pass
 

--- a/lib/tests/deployment/simple.py
+++ b/lib/tests/deployment/simple.py
@@ -7,7 +7,7 @@
 from mysql.replicant.server import Server
 from mysql.replicant.common import User
 from mysql.replicant.machine import Linux
-from mysql.replicant.roles import Master, Final
+from mysql.replicant.roles import Main, Final
 
 import time, os.path
 
@@ -37,18 +37,18 @@ def _cnf(name):
     test_dir = os.path.dirname(os.path.abspath(__file__))
     return os.path.join(test_dir, '..', name + ".cnf")
 
-master = Server(server_id=1, name="mysqld1",
+main = Server(server_id=1, name="mysqld1",
                 sql_user=_replicant_user,
                 ssh_user=User("mysql"),
-                machine=Linux(), role=Master(_REPL_USER),
+                machine=Linux(), role=Main(_REPL_USER),
                 port=3307,
                 socket='/var/run/mysqld/mysqld1.sock',
                 defaults_file=_cnf("mysqld1"),
                 config_section="mysqld1")
-slaves = [Server(server_id=2, name="mysqld2",
+subordinates = [Server(server_id=2, name="mysqld2",
                  sql_user=_replicant_user,
                  ssh_user=User("mysql"),
-                 machine=Linux(), role=Final(master),
+                 machine=Linux(), role=Final(main),
                  port=3308,
                  socket='/var/run/mysqld/mysqld2.sock',
                  defaults_file=_cnf("mysqld2"),
@@ -56,7 +56,7 @@ slaves = [Server(server_id=2, name="mysqld2",
           Server(server_id=3, name="mysqld3",
                  sql_user=_replicant_user,
                  ssh_user=User("mysql"),
-                 machine=Linux(), role=Final(master),
+                 machine=Linux(), role=Final(main),
                  port=3309,
                  socket='/var/run/mysqld/mysqld3.sock',
                  defaults_file=_cnf("mysqld3"),
@@ -64,9 +64,9 @@ slaves = [Server(server_id=2, name="mysqld2",
           Server(server_id=4, name="mysqld4",
                  sql_user=_replicant_user,
                  ssh_user=User("mysql"),
-                 machine=Linux(), role=Final(master),
+                 machine=Linux(), role=Final(main),
                  port=3310,
                  socket='/var/run/mysqld/mysqld4.sock',
                  defaults_file=_cnf("mysqld4"),
                  config_section="mysqld4")]
-servers = [master] + slaves
+servers = [main] + subordinates

--- a/lib/tests/test_backup.py
+++ b/lib/tests/test_backup.py
@@ -25,22 +25,22 @@ class TestBackup(unittest.TestCase):
         if options is None:
             options = {}
         deployment = tests.utils.load_deployment(options['deployment'])
-        self.master = deployment.master
+        self.main = deployment.main
 
     def setUp(self):
         self.backup = PhysicalBackup("file:/tmp/backup.tar.gz")
         
     def testPhysicalBackup(self):
-        self.master.sql("CREATE TABLE IF NOT EXISTS dummy (a INT)", db="test")
-        self.master.sql("INSERT INTO dummy VALUES (1),(2)", db="test")
-        for row in self.master.sql("SELECT * FROM dummy", db="test"):
+        self.main.sql("CREATE TABLE IF NOT EXISTS dummy (a INT)", db="test")
+        self.main.sql("INSERT INTO dummy VALUES (1),(2)", db="test")
+        for row in self.main.sql("SELECT * FROM dummy", db="test"):
             self.assertTrue(row['a'] in [1, 2])
-        self.backup.backup_server(self.master, ['test'])
-        self.master.sql("DROP TABLE dummy", db="test")
-        self.backup.restore_server(self.master)
-        tbls = self.master.sql("SHOW TABLES", db="test")
+        self.backup.backup_server(self.main, ['test'])
+        self.main.sql("DROP TABLE dummy", db="test")
+        self.backup.restore_server(self.main)
+        tbls = self.main.sql("SHOW TABLES", db="test")
         self.assertTrue('dummy' in [t["Tables_in_test"] for t in tbls])
-        self.master.sql("DROP TABLE dummy", db="test")
+        self.main.sql("DROP TABLE dummy", db="test")
 
 def suite(options=None):
     if options is None:

--- a/lib/tests/test_basic.py
+++ b/lib/tests/test_basic.py
@@ -38,9 +38,9 @@ class TestPosition(unittest.TestCase):
         
     def testSimple(self):
         positions = [
-            server.Position('master-bin.00001', 4711),
-            server.Position('master-bin.00001', 9393),
-            server.Position('master-bin.00002', 102),
+            server.Position('main-bin.00001', 4711),
+            server.Position('main-bin.00001', 9393),
+            server.Position('main-bin.00002', 102),
             ]
  
         for position in positions:

--- a/lib/tests/test_commands.py
+++ b/lib/tests/test_commands.py
@@ -14,7 +14,7 @@ import unittest
 
 from mysql.replicant.roles import (
     Final,
-    Master,
+    Main,
     )
 
 from mysql.replicant.server import (
@@ -22,11 +22,11 @@ from mysql.replicant.server import (
     )
 
 from mysql.replicant.commands import (
-    change_master,
-    fetch_master_position,
-    fetch_slave_position,
-    slave_wait_and_stop,
-    slave_wait_for_pos,
+    change_main,
+    fetch_main_position,
+    fetch_subordinate_position,
+    subordinate_wait_and_stop,
+    subordinate_wait_for_pos,
     )
 
 from tests.utils import load_deployment
@@ -37,90 +37,90 @@ class TestCommands(unittest.TestCase):
     def __init__(self, methodNames, options={}):
         super(TestCommands, self).__init__(methodNames)
         my = load_deployment(options['deployment'])
-        self.master = my.master
-        self.masters = my.servers[0:1]
-        self.slaves = my.servers[2:3]
+        self.main = my.main
+        self.mains = my.servers[0:1]
+        self.subordinates = my.servers[2:3]
 
     def setUp(self):
 
-        master_role = Master(User("repl_user", "xyzzy"))
-        for master in self.masters:
-            master_role.imbue(master)
+        main_role = Main(User("repl_user", "xyzzy"))
+        for main in self.mains:
+            main_role.imbue(main)
 
-        final_role = Final(self.masters[0])
-        for slave in self.slaves:
+        final_role = Final(self.mains[0])
+        for subordinate in self.subordinates:
             try:
-                final_role.imbue(slave)
+                final_role.imbue(subordinate)
             except IOError:
                 pass
 
-    def testChangeMaster(self):
-        "Test the change_master function"
-        for slave in self.slaves:
-            change_master(slave, self.master)
+    def testChangeMain(self):
+        "Test the change_main function"
+        for subordinate in self.subordinates:
+            change_main(subordinate, self.main)
 
-        self.master.sql("DROP TABLE IF EXISTS t1", db="test")
-        self.master.sql("CREATE TABLE t1 (a INT)", db="test")
-        self.master.disconnect()
+        self.main.sql("DROP TABLE IF EXISTS t1", db="test")
+        self.main.sql("CREATE TABLE t1 (a INT)", db="test")
+        self.main.disconnect()
 
-        for slave in self.slaves:
-            slave.sql("SHOW TABLES", db="test")
+        for subordinate in self.subordinates:
+            subordinate.sql("SHOW TABLES", db="test")
 
-    def testSlaveWaitForPos(self):
-        "Test the slave_wait_for_pos function"
+    def testSubordinateWaitForPos(self):
+        "Test the subordinate_wait_for_pos function"
 
-        slave = self.slaves[0]
-        master = self.master
+        subordinate = self.subordinates[0]
+        main = self.main
 
-        slave.sql("STOP SLAVE")
-        pos1 = fetch_master_position(master)
-        change_master(slave, master, pos1)
-        slave.sql("START SLAVE")
+        subordinate.sql("STOP SLAVE")
+        pos1 = fetch_main_position(main)
+        change_main(subordinate, main, pos1)
+        subordinate.sql("START SLAVE")
 
-        master.sql("DROP TABLE IF EXISTS t1", db="test")
-        master.sql("CREATE TABLE t1 (a INT)", db="test")
-        master.sql("INSERT INTO t1 VALUES (1),(2)", db="test")
-        pos2 = fetch_master_position(master)
-        slave_wait_for_pos(slave, pos2)
-        pos3 = fetch_slave_position(slave)
+        main.sql("DROP TABLE IF EXISTS t1", db="test")
+        main.sql("CREATE TABLE t1 (a INT)", db="test")
+        main.sql("INSERT INTO t1 VALUES (1),(2)", db="test")
+        pos2 = fetch_main_position(main)
+        subordinate_wait_for_pos(subordinate, pos2)
+        pos3 = fetch_subordinate_position(subordinate)
         self.assert_(pos3 >= pos2)
 
-    def testSlaveWaitAndStop(self):
-        "Test the slave_wait_and_stop function"
+    def testSubordinateWaitAndStop(self):
+        "Test the subordinate_wait_and_stop function"
 
-        slave = self.slaves[0]
-        master = self.master
+        subordinate = self.subordinates[0]
+        main = self.main
 
-        slave.sql("STOP SLAVE")
-        pos1 = fetch_master_position(master)
-        change_master(slave, master, pos1)
-        slave.sql("START SLAVE")
+        subordinate.sql("STOP SLAVE")
+        pos1 = fetch_main_position(main)
+        change_main(subordinate, main, pos1)
+        subordinate.sql("START SLAVE")
 
-        master.sql("DROP TABLE IF EXISTS t1", db="test")
-        master.sql("CREATE TABLE t1 (a INT)", db="test")
-        master.sql("INSERT INTO t1 VALUES (1),(2)", db="test")
-        pos2 = fetch_master_position(master)
-        master.sql("INSERT INTO t1 VALUES (3),(4)", db="test")
-        pos3 = fetch_master_position(master)
-        slave_wait_and_stop(slave, pos2)
-        pos4 = fetch_slave_position(slave)
+        main.sql("DROP TABLE IF EXISTS t1", db="test")
+        main.sql("CREATE TABLE t1 (a INT)", db="test")
+        main.sql("INSERT INTO t1 VALUES (1),(2)", db="test")
+        pos2 = fetch_main_position(main)
+        main.sql("INSERT INTO t1 VALUES (3),(4)", db="test")
+        pos3 = fetch_main_position(main)
+        subordinate_wait_and_stop(subordinate, pos2)
+        pos4 = fetch_subordinate_position(subordinate)
         self.assertEqual(pos2, pos4)
-        row = slave.sql("SELECT COUNT(*) AS count FROM t1", db="test")
+        row = subordinate.sql("SELECT COUNT(*) AS count FROM t1", db="test")
         self.assertEqual(row['count'], 2)
-        slave.sql("START SLAVE")
-        slave_wait_and_stop(slave, pos3)
-        row = slave.sql("SELECT COUNT(*) AS count FROM t1", db="test")
+        subordinate.sql("START SLAVE")
+        subordinate_wait_and_stop(subordinate, pos3)
+        row = subordinate.sql("SELECT COUNT(*) AS count FROM t1", db="test")
         self.assertEqual(row['count'], 4)
 
-    def testSlaveStatusWaitUntil(self):
-        "Test slave_status_wait_until"
-        slave = self.slaves[0]
-        master = self.master
+    def testSubordinateStatusWaitUntil(self):
+        "Test subordinate_status_wait_until"
+        subordinate = self.subordinates[0]
+        main = self.main
 
-        slave.sql("STOP SLAVE")
-        pos1 = fetch_master_position(master)
-        change_master(slave, master, pos1)
-        slave.sql("START SLAVE")
+        subordinate.sql("STOP SLAVE")
+        pos1 = fetch_main_position(main)
+        change_main(subordinate, main, pos1)
+        subordinate.sql("START SLAVE")
         
 
 def suite(options={}):

--- a/lib/tests/test_config.py
+++ b/lib/tests/test_config.py
@@ -31,8 +31,8 @@ class TestConfigFile(unittest.TestCase):
 
         self.assertEqual(config.get('user'), 'mysql')
         self.assertEqual(config.get('log-bin'),
-                         '/var/log/mysql/master-bin')
-        self.assertEqual(config.get('slave-skip-start'), None)
+                         '/var/log/mysql/main-bin')
+        self.assertEqual(config.get('subordinate-skip-start'), None)
 
     def testFetchReplace(self):
         "Fetching a configuration file, adding some options, and replacing it"

--- a/lib/tests/test_roles.py
+++ b/lib/tests/test_roles.py
@@ -20,9 +20,9 @@ class TestRoles(unittest.TestCase):
     def __init__(self, methodName, options):
         super(TestRoles, self).__init__(methodName)
         my = tests.utils.load_deployment(options['deployment'])
-        self.master = my.master
-        self.slave = my.slaves[0]
-        self.slaves = my.slaves
+        self.main = my.main
+        self.subordinate = my.subordinates[0]
+        self.subordinates = my.subordinates
 
     def setUp(self):
         pass
@@ -31,22 +31,22 @@ class TestRoles(unittest.TestCase):
         # We are likely to get an IOError because we cannot write the
         # configuration file, but this is OK.
         try:
-            role.imbue(self.master)
+            role.imbue(self.main)
         except IOError:
             pass
 
-    def testMasterRole(self):
-        "Test how the master role works"
+    def testMainRole(self):
+        "Test how the main role works"
         user = mysql.replicant.server.User("repl_user", "xyzzy")
-        self._imbueRole(mysql.replicant.roles.Master(user))
+        self._imbueRole(mysql.replicant.roles.Main(user))
         
-    def testSlaveRole(self):
-        "Test that the slave role works"
-        self._imbueRole(mysql.replicant.roles.Final(self.master))
+    def testSubordinateRole(self):
+        "Test that the subordinate role works"
+        self._imbueRole(mysql.replicant.roles.Final(self.main))
 
     def testRelayRole(self):
-        "Test that the slave role works"
-        self._imbueRole(mysql.replicant.roles.Relay(self.master))
+        "Test that the subordinate role works"
+        self._imbueRole(mysql.replicant.roles.Relay(self.main))
 
 def suite(options={}):
     if not options['deployment']:

--- a/lib/tests/test_server.py
+++ b/lib/tests/test_server.py
@@ -14,13 +14,13 @@ import re
 import unittest
 
 from mysql.replicant.errors import (
-    NotMasterError,
-    NotSlaveError,
+    NotMainError,
+    NotSubordinateError,
     )
 
 from mysql.replicant.commands import (
-    fetch_master_position,
-    fetch_slave_position,
+    fetch_main_position,
+    fetch_subordinate_position,
     lock_database,
     unlock_database,
     )
@@ -36,25 +36,25 @@ class TestServerBasics(unittest.TestCase):
     def __init__(self, method_name, options):
         super(TestServerBasics, self).__init__(method_name)
         depl = tests.utils.load_deployment(options['deployment'])
-        self.master = depl.master
-        self.slave = depl.slaves[0]
-        self.slaves = depl.slaves
+        self.main = depl.main
+        self.subordinate = depl.subordinates[0]
+        self.subordinates = depl.subordinates
 
     def setUp(self):
         pass
 
     def testConfig(self):
         "Get some configuration information from the server"
-        self.assertEqual(self.master.host, "localhost")
-        self.assertEqual(self.master.port, 3307)
-        self.assertEqual(self.master.socket, '/var/run/mysqld/mysqld1.sock')
+        self.assertEqual(self.main.host, "localhost")
+        self.assertEqual(self.main.port, 3307)
+        self.assertEqual(self.main.socket, '/var/run/mysqld/mysqld1.sock')
 
     def testFetchReplace(self):
         "Fetching a configuration file, adding some options, and replacing it"
-        config = self.master.fetch_config(os.path.join(here, 'test.cnf'))
+        config = self.main.fetch_config(os.path.join(here, 'test.cnf'))
         self.assertEqual(config.get('user'), 'mysql')
-        self.assertEqual(config.get('log-bin'), '/var/log/mysql/master-bin')
-        self.assertEqual(config.get('slave-skip-start'), None)
+        self.assertEqual(config.get('log-bin'), '/var/log/mysql/main-bin')
+        self.assertEqual(config.get('subordinate-skip-start'), None)
         config.set('no-value')
         self.assertEqual(config.get('no-value'), None)
         config.set('with-int-value', 4711)
@@ -62,7 +62,7 @@ class TestServerBasics(unittest.TestCase):
         config.set('with-string-value', 'Careful with that axe, Eugene!')
         self.assertEqual(config.get('with-string-value'),
                          'Careful with that axe, Eugene!')
-        self.master.replace_config(config, os.path.join(here, 'test-new.cnf'))
+        self.main.replace_config(config, os.path.join(here, 'test-new.cnf'))
         lines1 = file(os.path.join(here, 'test.cnf')).readlines()
         lines2 = file(os.path.join(here, 'test-new.cnf')).readlines()
         lines1 += ["\n", "no-value\n", "with-int-value = 4711\n",
@@ -75,39 +75,39 @@ class TestServerBasics(unittest.TestCase):
         
     def testSsh(self):
         "Testing ssh() call"
-        self.assertEqual(''.join(self.master.ssh(["echo", "-n", "Hello"])),
+        self.assertEqual(''.join(self.main.ssh(["echo", "-n", "Hello"])),
                          "Hello")
  
     def testSql(self):
         "Testing (read-only) SQL execution"
-        result = self.master.sql("select 'Hello' as val")['val']
+        result = self.main.sql("select 'Hello' as val")['val']
         self.assertEqual(result, "Hello")
 
     def testLockUnlock(self):
         "Test that the lock and unlock functions can be called"
-        lock_database(self.master)
-        unlock_database(self.master)
+        lock_database(self.main)
+        unlock_database(self.main)
 
-    def testGetMasterPosition(self):
-        "Fetching master position from the master and checking format"
+    def testGetMainPosition(self):
+        "Fetching main position from the main and checking format"
         try:
-            position = fetch_master_position(self.master)
+            position = fetch_main_position(self.main)
             self.assertTrue(position is None or _POS_CRE.match(str(position)),
                             "Position '%s' is not correct" % (str(position)))
-        except NotMasterError:
+        except NotMainError:
             self.fail(
-                "Unable to test fetch_master_position since"
-                " master is not configured as a master"
+                "Unable to test fetch_main_position since"
+                " main is not configured as a main"
                 )
 
-    def testGetSlavePosition(self):
-        "Fetching slave positions from the slaves and checking format"
-        for slave in self.slaves:
+    def testGetSubordinatePosition(self):
+        "Fetching subordinate positions from the subordinates and checking format"
+        for subordinate in self.subordinates:
             try:
-                position = fetch_slave_position(slave)
+                position = fetch_subordinate_position(subordinate)
                 self.assertTrue(_POS_CRE.match(str(position)),
                                 "Incorrect position '%s'" % (str(position)))
-            except NotSlaveError:
+            except NotSubordinateError:
                 pass
 
 def suite(options={}):


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.